### PR TITLE
Rebuilt secondary navigation stack on expand

### DIFF
--- a/MasterDetailDemo/AppDelegate.swift
+++ b/MasterDetailDemo/AppDelegate.swift
@@ -40,6 +40,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         }
         return false
     }
+    
+    func splitViewController(splitViewController: UISplitViewController, separateSecondaryViewControllerFromPrimaryViewController primaryViewController: UIViewController) -> UIViewController? {
+        guard let
+            primaryNav = primaryViewController as? UINavigationController,
+            secondary = primaryNav.visibleViewController
+            else { return nil }
+        // Depending on your requirements you may need to remove more than just the top view controller.
+        primaryNav.popViewControllerAnimated(false)
+        return UINavigationController(rootViewController: secondary)
+    }
 
 }
 


### PR DESCRIPTION
This is what I meant. Before you were doing nothing on expand, meaning that the split VC was asking the primary navigation controller to separate the secondary itself - it does this just by popping the top controller off the stack. This meant the detail controller was on its own rather than contained within a navigation controller. 

Because you discard the navigation controller from the secondary stack when you collapse, you have to put it back when you expand. 

Hope this makes sense! 
